### PR TITLE
Lock in Ubuntu at 22.04

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -89,7 +89,7 @@
 				"(^|\\/)action\\.[Yy][Aa]?[Mm][Ll]$",
 			],
 			matchStrings: [
-				"runs-on:\\s+(?<depName>ubuntu|macos|windows)-(?<currentValue>.+)",
+				"runs-on:\\s*['\"]?(?<depName>ubuntu)-(?<currentValue>.+)['\"]?",
 			],
 			datasourceTemplate: "github-runners",
 			versioningTemplate: "docker",

--- a/default.json5
+++ b/default.json5
@@ -80,4 +80,21 @@
 		description: "Update Gradle wrapper to non-stable versions",
 		ignoreUnstable: false,
 	},
+	customManagers: [
+		{
+			customType: "regex",
+			description: "GitHub Actions latest runners",
+			fileMatch: [
+				"^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.[Yy][Aa]?[Mm][Ll]$",
+				"(^|\\/)action\\.[Yy][Aa]?[Mm][Ll]$",
+			],
+			matchStrings: [
+				"runs-on:\\s+(?<depName>ubuntu|macos|windows)-(?<currentValue>.+)",
+			],
+			datasourceTemplate: "github-runners",
+			versioningTemplate: "docker",
+			currentValueTemplate: "{{#if (equals currentValue 'latest')}}22.04{{else}}{{{currentValue}}}{{/if}}",
+			autoReplaceStringTemplate: "runs-on: {{{depName}}}-{{{newValue}}}",
+		},
+	]
 }


### PR DESCRIPTION
This should trigger `ubuntu-latest` -> `ubuntu-24.04` upgrades.

https://www.notion.so/twisterrob/Ubuntu-latest-e34438af06aa4ca3a1b50ddf60cb58a3?pvs=4