### PR TITLE
Enable rollback PRs

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -16,6 +16,7 @@
 	separateMinorPatch: true,
 	minimumReleaseAge: "8 hours",
 	internalChecksFilter: "strict",
+	rollbackPrs: true,
 	ignorePaths: [
 		"do-not-ignore-anything",
 	],


### PR DESCRIPTION
Enable Renovate rollback PRs so yanked or removed releases can be reverted automatically.

From https://www.augmentedmind.de/2023/07/30/renovate-bot-cheat-sheet/