### PR TITLE
Use pinned Renovate for config validation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,8 +31,8 @@
 		{
 			customType: "regex",
 			description: "Renovate version used by CI config validation.",
-			fileMatch: [
-				"^\\.github/workflows/renovate-config-validator\\.yml$",
+			managerFilePatterns: [
+				"/^\\.github/workflows/renovate-config-validator\\.yml$/",
 			],
 			matchStrings: [
 				"RENOVATE_VERSION: '(?<currentValue>.*?)' # Renovated\\.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,4 +27,18 @@
 			enabled: false,
 		},
 	],
+	customManagers: [
+		{
+			customType: "regex",
+			description: "Renovate version used by CI config validation.",
+			fileMatch: [
+				"^\\.github/workflows/renovate-config-validator\\.yml$",
+			],
+			matchStrings: [
+				"RENOVATE_VERSION: '(?<currentValue>.*?)' # Renovated\\.",
+			],
+			datasourceTemplate: "npm",
+			depNameTemplate: "renovate",
+		},
+	],
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
   validate:
     name: "🦺 Validation"
-    uses: TWiStErRob/github-workflows/.github/workflows/validate.yml@b2ac1bf35e26a7042bbedcd6815faaee3f20a2a8 # v3
+    uses: TWiStErRob/github-workflows/.github/workflows/validate.yml@104620e2c495f0c905fde6f15ea2b6453ae4eaed # v3.7.0
     with:
       gradle: false
     permissions:

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -79,7 +79,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     env:
-      RENOVATE_VERSION: '43.242.2' # Renovated.
+      RENOVATE_VERSION: '43.245.0' # Renovated.
     steps:
 
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -82,6 +82,13 @@ jobs:
       RENOVATE_VERSION: '43.245.0' # Renovated.
     steps:
 
+      - name: "Cache NPX."
+        uses: actions/cache@v5
+        with:
+          key: npx-${{ github.workflow }}-${{ github.job }}-${{ env.RENOVATE_VERSION }}
+          path: |
+            ~/.npm/_npx
+
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
         uses: actions/checkout@v6
 
@@ -89,13 +96,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
-
-      - name: "Cache NPX."
-        uses: actions/cache@v5
-        with:
-          key: npx-${{ github.workflow }}-${{ github.job }}-${{ env.RENOVATE_VERSION }}
-          path: |
-            ~/.npm/_npx
 
       - name: "Run renovate-config-validator on ${{ env.FILE }}."
         env:

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -86,7 +86,7 @@ jobs:
       - name: "Set up Node."
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version-file: package.json
 
       - name: "Cache NPX."
         uses: actions/cache@v5

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -80,13 +80,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-      - name: "Cache NPX."
-        uses: actions/cache@v5
-        with:
-          key: npx-${{ github.workflow }}-${{ github.job }}
-          path: |
-            ~/.npm/_npx
-
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
         uses: actions/checkout@v6
 
@@ -94,11 +87,12 @@ jobs:
         env:
           FILE: ${{ matrix.config-file }}
         shell: bash
-        run: >
-          npx
-          --yes
-          --package renovate
-          --
-          renovate-config-validator
-          --strict
-          "${FILE}"
+        run: |
+          renovateVersion="$(node -p "require('./package.json').devDependencies.renovate")"
+          npx \
+            --yes \
+            --package "renovate@${renovateVersion}" \
+            -- \
+            renovate-config-validator \
+            --strict \
+            "${FILE}"

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -83,6 +83,18 @@ jobs:
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
         uses: actions/checkout@v6
 
+      - name: "Set up Node."
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: "Cache NPX."
+        uses: actions/cache@v5
+        with:
+          key: npx-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('package.json') }}
+          path: |
+            ~/.npm/_npx
+
       - name: "Run renovate-config-validator on ${{ env.FILE }}."
         env:
           FILE: ${{ matrix.config-file }}

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -79,7 +79,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     env:
-      RENOVATE_VERSION: '43.4.4' # Renovated.
+      RENOVATE_VERSION: '43.242.2' # Renovated.
     steps:
 
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -78,6 +78,8 @@ jobs:
       # actions/checkout
       contents: read
     runs-on: ubuntu-24.04
+    env:
+      RENOVATE_VERSION: '43.4.4' # Renovated.
     steps:
 
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
@@ -91,7 +93,7 @@ jobs:
       - name: "Cache NPX."
         uses: actions/cache@v5
         with:
-          key: npx-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('package.json') }}
+          key: npx-${{ github.workflow }}-${{ github.job }}-${{ env.RENOVATE_VERSION }}
           path: |
             ~/.npm/_npx
 
@@ -99,12 +101,11 @@ jobs:
         env:
           FILE: ${{ matrix.config-file }}
         shell: bash
-        run: |
-          renovateVersion="$(node -p "require('./package.json').devDependencies.renovate")"
-          npx \
-            --yes \
-            --package "renovate@${renovateVersion}" \
-            -- \
-            renovate-config-validator \
-            --strict \
-            "${FILE}"
+        run: >
+          npx
+          --yes
+          --package "renovate@${RENOVATE_VERSION}"
+          --
+          renovate-config-validator
+          --strict
+          "${FILE}"

--- a/default.json5
+++ b/default.json5
@@ -136,9 +136,9 @@
 		{
 			customType: "regex",
 			description: "GitHub Actions latest runners",
-			fileMatch: [
-				"^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.[Yy][Aa]?[Mm][Ll]$",
-				"(^|\\/)action\\.[Yy][Aa]?[Mm][Ll]$",
+			managerFilePatterns: [
+				"/^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.[Yy][Aa]?[Mm][Ll]$/",
+				"/(^|\\/)action\\.[Yy][Aa]?[Mm][Ll]$/",
 			],
 			matchStrings: [
 				"runs-on:\\s*['\"]?(?<depName>ubuntu)-(?<currentValue>.+)['\"]?",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	},
 	"devDependencies": {
 		"json5": "2.2.3",
-		"renovate": "43.242.2"
+		"renovate": "43.245.0"
 	},
 	"engines": {
 		"node": "24"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 		"json5": "2.2.3",
 		"renovate": "43.4.4"
 	},
+	"engines": {
+		"node": "24"
+	},
 	"jshintConfig": {
 		"esversion": 9
 	}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	},
 	"devDependencies": {
 		"json5": "2.2.3",
-		"renovate": "43.4.4"
+		"renovate": "43.242.2"
 	},
 	"engines": {
 		"node": "24"

--- a/renovate-update-notification/Dockerfile
+++ b/renovate-update-notification/Dockerfile
@@ -1,3 +1,3 @@
 # This file is processed by Renovate bot so that it creates a PR on new Renovate versions.
 # https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet/#11-keep-up-to-date-with-renovate-bots-development
-FROM renovate/renovate:43.0.2
+FROM renovate/renovate:43.242.2

--- a/renovate-update-notification/Dockerfile
+++ b/renovate-update-notification/Dockerfile
@@ -1,3 +1,3 @@
 # This file is processed by Renovate bot so that it creates a PR on new Renovate versions.
 # https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet/#11-keep-up-to-date-with-renovate-bots-development
-FROM renovate/renovate:43.242.2
+FROM renovate/renovate:43.245.0


### PR DESCRIPTION
Make the Renovate config validator use the Renovate version declared in package.json instead of an unversioned npx package. This avoids stale ~/.npm/_npx cache entries causing CI to validate with an older Renovate version, as seen on #98.