### PR TITLE
Update ubuntu-latest baseline

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -146,7 +146,7 @@
 			],
 			datasourceTemplate: "github-runners",
 			versioningTemplate: "docker",
-			currentValueTemplate: "{{#if (equals currentValue 'latest')}}22.04{{else}}{{{currentValue}}}{{/if}}",
+			currentValueTemplate: "{{#if (equals currentValue 'latest')}}24.04{{else}}{{{currentValue}}}{{/if}}",
 			autoReplaceStringTemplate: "runs-on: {{{depName}}}-{{{newValue}}}",
 		},
 	]


### PR DESCRIPTION
Treat accidental ubuntu-latest workflow usage as Ubuntu 24.04 when Renovate checks GitHub runner updates.

GitHub code search found no exact current runs-on: ubuntu-latest matches in owned repos, so this remains a safety net for future accidental usage.