### PR TITLE
Use pinned JSON5 for config validation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,18 @@
 	customManagers: [
 		{
 			customType: "regex",
+			description: "JSON5 version used by CI config validation.",
+			managerFilePatterns: [
+				"/^\\.github/workflows/renovate-config-validator\\.yml$/",
+			],
+			matchStrings: [
+				"JSON5_VERSION: '(?<currentValue>.*?)' # Renovated\\.",
+			],
+			datasourceTemplate: "npm",
+			depNameTemplate: "json5",
+		},
+		{
+			customType: "regex",
 			description: "Renovate version used by CI config validation.",
 			managerFilePatterns: [
 				"/^\\.github/workflows/renovate-config-validator\\.yml$/",

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -29,17 +29,24 @@ jobs:
       # actions/checkout
       contents: read
     runs-on: ubuntu-24.04
+    env:
+      JSON5_VERSION: '2.2.3' # Renovated.
     steps:
 
       - name: "Cache NPX."
         uses: actions/cache@v6
         with:
-          key: npx-${{ github.workflow }}-${{ github.job }}
+          key: npx-${{ github.workflow }}-${{ github.job }}-${{ env.JSON5_VERSION }}
           path: |
             ~/.npm/_npx
 
       - name: "Checkout ${{ github.ref }} branch in ${{ github.repository }} repository."
         uses: actions/checkout@v7
+
+      - name: "Set up Node."
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
 
       - name: "Run json5 validator on ${{ env.FILE }}."
         env:
@@ -48,6 +55,8 @@ jobs:
         run: >
           npx
           --yes
+          --package "json5@${JSON5_VERSION}"
+          --
           json5
           --validate
           "${FILE}"


### PR DESCRIPTION
Pin the JSON5 CLI used by config validation instead of relying on unversioned npx resolution.

This mirrors the Renovate validator setup: the npx cache key includes the tool version, and this repo's Renovate config has a custom manager to update the workflow-pinned JSON5 version.