### PR TITLE
Revert "Disable AGP 8→9 Renovate PRs until Detekt compatibility lands"

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -90,13 +90,6 @@
 			pinDigests: true,
 		},
 		{
-			description: "Disable AGP major updates from 8 to 9 until detekt supports AGP 9.",
-			matchSourceUrls: ["https://android.googlesource.com/platform/tools/base"],
-			matchUpdateTypes: ["major"],
-			matchNewValue: "/^9\\./",
-			enabled: false,
-		},
-		{
 			description: "Disable Gradle wrapper milestone releases, only interested stables and RCs for now.",
 			matchPackageNames: [
 				"gradle",


### PR DESCRIPTION
Reverts TWiStErRob/renovate-config#85

2.0.0-alpha.2 was already compatible.

https://github.com/detekt/detekt/blob/v2.0.0-alpha.5/README.md#requirements